### PR TITLE
chore(otel): bump SDK collector chart 1.23.0 → 1.35.0

### DIFF
--- a/otel-collector-sidecar/main.tf
+++ b/otel-collector-sidecar/main.tf
@@ -2,7 +2,7 @@ resource "helm_release" "otel_collector_sidecar" {
   name             = "otel-collector-sidecar"
   repository       = "oci://europe-docker.pkg.dev"
   chart            = "hozah-artifacts/docker/hozah/otel-collector-sidecar"
-  version          = "1.23.0"
+  version          = "1.35.0"
   namespace        = var.k8s_namespace
   create_namespace = true
 }


### PR DESCRIPTION
## Summary

Bump the chart version pinned in `otel-collector-sidecar/main.tf` to pick up [kubernetes-commons#28](https://github.com/VHZHV/kubernetes-commons/pull/28), which migrates the SDK OTel collector pipeline from the legacy `googlecloud` metrics exporter to `otlphttp/gmp` (Telemetry API → Google Managed Prometheus).

Companion to that already-merged work.

## Blast radius

Every consumer of `terraform-modules//otel-collector-sidecar` that bumps their `?ref=` to the tag created from this PR will switch to the GMP exporter. Known consumers:

- anpr, account, console (via retool-2-react)

Each consumer migrates **only when they bump their own `?ref`** — Terraform module versioning is pull, not push. No coordinated rollout required.

## Prerequisites for consumers before bumping

1. Enable `telemetry.googleapis.com` API in the project.
2. Grant `roles/telemetry.metricsWriter` to each workload SA — **keep** the existing `roles/monitoring.metricWriter` (both are needed; removing the old role breaks ingestion).
3. Run `kubectl delete opentelemetrycollector --all -n <namespace>` before `terraform apply` to clear the ghost `service.telemetry.metrics.address` field that the old operator wrote via managed fields. Without this, collector 0.148.0 will reject the CRD (Gotcha #2 from `otel-gmp-migration-prompt.md`).

## What does NOT change here

- `otel-sidecar-config` chart version (the env-var ConfigMap) — already bumped in #106
- `otel-temporal-collector-sidecar` — no terraform-modules wrapper exists; consumers reference that OCI chart directly in their own `helm_release` blocks. Each consumer bumps it in their own infra at the same time as bumping this terraform-modules ref.

## Test plan

Cannot be tested standalone. Validation happens during the first consumer rollout (anpr develop):

- [ ] Collector pod stable for >=1h after apply
- [ ] `otelcol_exporter_sent_metric_points_total{exporter="otlphttp/gmp"}` increments on :8888
- [ ] Zero `Partial success response` warnings in collector logs for >=30 min
- [ ] Data flowing at `prometheus.googleapis.com/*` paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)