### PR TITLE
ISME-4491 - Bump kube-services chart to 1.38.0 (probe timing fix)

### DIFF
--- a/hozah_helm/outputs.tf
+++ b/hozah_helm/outputs.tf
@@ -1,6 +1,6 @@
 # This mainly exists to keep everyone up to date with kubernetes-commons, as dependabot can't really look at helm in terraform
 output "version" {
-  value = "1.37.0"
+  value = "1.38.0"
 }
 output "repository" {
   value = "oci://europe-docker.pkg.dev"


### PR DESCRIPTION
Bumps the `hozah_helm` chart version output `1.37.0 → 1.38.0`.

`kube-services` 1.38.0 (kubernetes-commons#31, merged & published to Artifact Registry) carries the probe-timing fix: the chart previously emitted liveness/readiness probes with only an HTTP path, so Kubernetes defaults applied (`timeoutSeconds=1`, `failureThreshold=3`). On the shared single-node prod cluster, JVM edge services couldn't always answer the actuator health endpoint within 1s during GC/CPU contention, so healthy pods were killed by the kubelet (exit 143) — the repeated ~10-minute outage windows on ISME-4491. 1.38.0 sets JVM-safe, per-service-overridable defaults (liveness ~100s tolerance).

## Next step after merge

Bump the `?ref` pin in enforcement's `09-per-environment-region-services` to the new terraform-modules tag, then `terraform apply` — this replaces the live `kubectl patch` stop-gap with the chart-managed config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)