### PR TITLE
[HPS-763] Enforce Cloud SQL SSL-only (Datastream compatibility)

### DIFF
--- a/sql-postgres/main.tf
+++ b/sql-postgres/main.tf
@@ -61,7 +61,7 @@ module "sql-db_postgresql" {
   } : null
   ip_configuration = {
     ipv4_enabled    = true
-    ssl_mode        = "ALLOW_UNENCRYPTED_AND_ENCRYPTED"
+    ssl_mode        = "ENCRYPTED_ONLY"
     private_network = data.google_compute_network.network.id
     authorized_networks = [for ip in data.google_datastream_static_ips.datastream_ips.static_ips : {
       value = ip


### PR DESCRIPTION
Given it a try here: https://console.cloud.google.com/sql/instances/console-ew2/overview?project=hozah-console-develop

And seems to be sending over to datastream still https://console.cloud.google.com/datastream/streams/locations/europe-west2/instances/postgres-to-bigquery-console-ew2-develop;tab=monitoring?project=hozah-console-develop