### PR TITLE
HPS-842 - Support read-only grantees and extra authorized networks

### DIFF
--- a/cloud-sql-permissions/README.md
+++ b/cloud-sql-permissions/README.md
@@ -30,6 +30,7 @@ No modules.
 | ---- | ----------- | ---- | ------- | :------: |
 | <a name="input_database_name"></a> [database\_name](#input\_database\_name) | Name of the database inside the instance connection | `string` | n/a | yes |
 | <a name="input_extra_commands"></a> [extra\_commands](#input\_extra\_commands) | Extra commands to run after the database is created | `list(string)` | `[]` | no |
+| <a name="input_grant_write"></a> [grant\_write](#input\_grant\_write) | Whether to grant write access (pg\_write\_all\_data) to the grantee. Set false for read-only users such as analytics/Metabase (they still get pg\_read\_all\_data). | `bool` | `true` | no |
 | <a name="input_grantee"></a> [grantee](#input\_grantee) | The user to grant permissions to | `string` | n/a | yes |
 | <a name="input_instance_connection_name"></a> [instance\_connection\_name](#input\_instance\_connection\_name) | Cloud SQL connection name | `string` | n/a | yes |
 | <a name="input_user_name"></a> [user\_name](#input\_user\_name) | Admin username | `string` | n/a | yes |

--- a/cloud-sql-permissions/main.tf
+++ b/cloud-sql-permissions/main.tf
@@ -9,6 +9,7 @@ locals {
         var.user_name,
         var.user_password,
         var.database_name,
+        tostring(var.grant_write),
       ],
       var.extra_commands,
     )
@@ -30,6 +31,7 @@ resource "null_resource" "run_grant_sql_access" {
       DATABASE_NAME            = var.database_name
       APP_USERNAME             = var.grantee
       EXTRA_COMMANDS           = join("", var.extra_commands)
+      GRANT_WRITE              = tostring(var.grant_write)
     }
   }
 }

--- a/cloud-sql-permissions/scripts/grant_sql_access/index.mjs
+++ b/cloud-sql-permissions/scripts/grant_sql_access/index.mjs
@@ -31,8 +31,13 @@ process.env.EXTRA_COMMANDS.split(";")
         );
     });
 await pool.query(
-    `GRANT pg_read_all_data, pg_write_all_data TO "${process.env.APP_USERNAME}";`,
+    `GRANT pg_read_all_data TO "${process.env.APP_USERNAME}";`,
 );
+if (process.env.GRANT_WRITE !== "false") {
+    await pool.query(
+        `GRANT pg_write_all_data TO "${process.env.APP_USERNAME}";`,
+    );
+}
 
 await pool.query(
     `GRANT pg_read_all_data, pg_write_all_data TO "${process.env.USER_NAME}";`,

--- a/cloud-sql-permissions/variables.tf
+++ b/cloud-sql-permissions/variables.tf
@@ -29,3 +29,9 @@ variable "extra_commands" {
   type        = list(string)
   default     = []
 }
+
+variable "grant_write" {
+  description = "Whether to grant write access (pg_write_all_data) to the grantee. Set false for read-only users such as analytics/Metabase (they still get pg_read_all_data)."
+  type        = bool
+  default     = true
+}

--- a/sql-postgres/README.md
+++ b/sql-postgres/README.md
@@ -33,6 +33,7 @@
 
 | Name | Description | Type | Default | Required |
 | ---- | ----------- | ---- | ------- | :------: |
+| <a name="input_additional_authorized_networks"></a> [additional\_authorized\_networks](#input\_additional\_authorized\_networks) | Extra external IPv4 addresses/CIDRs allowed to reach the instance's public IP, on top of the Datastream static IPs (e.g. Metabase Cloud egress IPs). | `list(string)` | `[]` | no |
 | <a name="input_allow_unencrypted_connections"></a> [allow\_unencrypted\_connections](#input\_allow\_unencrypted\_connections) | Whether to enforce SSL encryption requirements for direct connections. Encryption helps to ensure secure data transfer. Really think about setting this to true | `bool` | `false` | no |
 | <a name="input_db_available_type"></a> [db\_available\_type](#input\_db\_available\_type) | Defines possible options for autoscalingProfile field. | `string` | n/a | yes |
 | <a name="input_db_backup"></a> [db\_backup](#input\_db\_backup) | Whether to enable database backup. | `bool` | n/a | yes |

--- a/sql-postgres/main.tf
+++ b/sql-postgres/main.tf
@@ -63,9 +63,14 @@ module "sql-db_postgresql" {
     ipv4_enabled    = true
     ssl_mode        = var.allow_unencrypted_connections ? "ALLOW_UNENCRYPTED_AND_ENCRYPTED" : "ENCRYPTED_ONLY"
     private_network = data.google_compute_network.network.id
-    authorized_networks = [for ip in data.google_datastream_static_ips.datastream_ips.static_ips : {
-      value = ip
-    }]
+    authorized_networks = concat(
+      [for ip in data.google_datastream_static_ips.datastream_ips.static_ips : {
+        value = ip
+      }],
+      [for ip in var.additional_authorized_networks : {
+        value = ip
+      }],
+    )
   }
 
   database_flags = [

--- a/sql-postgres/variables.tf
+++ b/sql-postgres/variables.tf
@@ -51,6 +51,11 @@ variable "allow_unencrypted_connections" {
   type        = bool
   default     = false
 }
+variable "additional_authorized_networks" {
+  description = "Extra external IPv4 addresses/CIDRs allowed to reach the instance's public IP, on top of the Datastream static IPs (e.g. Metabase Cloud egress IPs)."
+  type        = list(string)
+  default     = []
+}
 locals {
   zones   = data.google_compute_zones.available.names
   db_zone = var.db_zone_selector == "*" ? null : local.zones[tonumber(var.db_zone_selector)]


### PR DESCRIPTION
Part of work to give Metabase access to the account production DB.

- sql-postgres: additional_authorized_networks var
- cloud-sql-permissions: grant_write flag (default true) to allow read-only users; grants pg_read_all_data always, pg_write_all_data only when enabled

Related PR: https://github.com/VHZHV/account/pull/392

https://hozah.atlassian.net/browse/HPS-842