### PR TITLE
sql-postgres: optional wal_compression + max_wal_size flags

### DIFF
--- a/sql-postgres/README.md
+++ b/sql-postgres/README.md
@@ -41,10 +41,12 @@
 | <a name="input_db_zone_selector"></a> [db\_zone\_selector](#input\_db\_zone\_selector) | Zone selector for the database. If set to *, all zones will be used. | `string` | n/a | yes |
 | <a name="input_deletion_protection"></a> [deletion\_protection](#input\_deletion\_protection) | Whether to enable deletion protection for the database. | `bool` | n/a | yes |
 | <a name="input_max_connections"></a> [max\_connections](#input\_max\_connections) | The maximum number of connections to the database. | `string` | `"2000"` | no |
+| <a name="input_max_wal_size"></a> [max\_wal\_size](#input\_max\_wal\_size) | max\_wal\_size in MB. Empty string leaves the Cloud SQL tier default unset. | `string` | `""` | no |
 | <a name="input_network_name"></a> [network\_name](#input\_network\_name) | The name of the network to use for the database | `string` | n/a | yes |
 | <a name="input_project_id"></a> [project\_id](#input\_project\_id) | The project ID to host the db in | `string` | n/a | yes |
 | <a name="input_region"></a> [region](#input\_region) | The region to host the db in | `string` | n/a | yes |
 | <a name="input_tier"></a> [tier](#input\_tier) | The tier for the Cloud SQL instance. | `string` | `"db-f1-micro"` | no |
+| <a name="input_wal_compression"></a> [wal\_compression](#input\_wal\_compression) | WAL compression method (off, on, pglz, lz4, zstd). Empty string leaves the Cloud SQL tier default unset. | `string` | `""` | no |
 
 ## Outputs
 

--- a/sql-postgres/main.tf
+++ b/sql-postgres/main.tf
@@ -68,7 +68,7 @@ module "sql-db_postgresql" {
     }]
   }
 
-  database_flags = [
+  database_flags = concat([
     {
       name : "cloudsql.logical_decoding",
       value : "on"
@@ -105,7 +105,13 @@ module "sql-db_postgresql" {
       name : "log_checkpoints",
       value : "on"
     },
-  ]
+    ],
+    # Optional WAL/checkpoint tuning. Empty (default) => flag not set, so the
+    # Cloud SQL tier default is left untouched for every instance that does not
+    # explicitly opt in.
+    var.wal_compression != "" ? [{ name : "wal_compression", value : var.wal_compression }] : [],
+    var.max_wal_size != "" ? [{ name : "max_wal_size", value : var.max_wal_size }] : [],
+  )
 }
 
 resource "google_sql_user" "gcp_developers" {

--- a/sql-postgres/variables.tf
+++ b/sql-postgres/variables.tf
@@ -46,6 +46,16 @@ variable "max_connections" {
   type        = string
   default     = "2000"
 }
+variable "wal_compression" {
+  description = "WAL compression method (off, on, pglz, lz4, zstd). Empty string leaves the Cloud SQL tier default unset."
+  type        = string
+  default     = ""
+}
+variable "max_wal_size" {
+  description = "max_wal_size in MB. Empty string leaves the Cloud SQL tier default unset."
+  type        = string
+  default     = ""
+}
 variable "allow_unencrypted_connections" {
   description = "Whether to enforce SSL encryption requirements for direct connections. Encryption helps to ensure secure data transfer. Really think about setting this to true"
   type        = bool


### PR DESCRIPTION
## What
Adds two **optional** inputs to the `sql-postgres` module: `wal_compression` and `max_wal_size`.

Both default to `""`. The flag is only appended to `database_flags` when a caller sets a non-empty value, so **every existing instance is unaffected** — the Cloud SQL tier defaults are left untouched unless a caller explicitly opts in.

## Why
High-throughput Temporal persistence in `anpr-production` generates WAL fast enough to hit the `max_wal_size` default (1504 MB) roughly every **27 seconds**, forcing a continuous checkpoint storm (Postgres logs `checkpoints are occurring too frequently` + `HINT: increase max_wal_size`). That saturates DB I/O, slows queries, and is implicated in the matching connection-handle wedge / task-queue partition-starvation incidents.

- `wal_compression=zstd` shrinks the FPI-heavy WAL at source.
- `max_wal_size` (MB) lets checkpoints fall back onto the time trigger.

Both flags are `requiresRestart=false` -> online apply, no instance restart.

## Blast radius
- Empty defaults -> no change to any current caller.
- First consumer: `anpr` production only (via `TF_VAR_db_*`).

Release as `0.185.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)