### PR TITLE
db: honour `deletable` instead of always setting DELETE

### DIFF
--- a/db/main.tf
+++ b/db/main.tf
@@ -10,8 +10,5 @@ resource "google_sql_database" "main_database" {
   name     = var.database_name
   instance = var.cloud_sql_instance_name
 
-  # `deletable` is a bool, so comparing it to "" was never true and every
-  # database got DELETE regardless of the flag — including production ones set
-  # to false. Honour the variable as documented.
   deletion_policy = var.deletable ? "DELETE" : "ABANDON"
 }

--- a/db/main.tf
+++ b/db/main.tf
@@ -10,5 +10,8 @@ resource "google_sql_database" "main_database" {
   name     = var.database_name
   instance = var.cloud_sql_instance_name
 
-  deletion_policy = var.deletable == "" ? "ABANDON" : "DELETE"
+  # `deletable` is a bool, so comparing it to "" was never true and every
+  # database got DELETE regardless of the flag — including production ones set
+  # to false. Honour the variable as documented.
+  deletion_policy = var.deletable ? "DELETE" : "ABANDON"
 }


### PR DESCRIPTION
## What it does

```diff
-  deletion_policy = var.deletable == "" ? "ABANDON" : "DELETE"
+  deletion_policy = var.deletable ? "DELETE" : "ABANDON"
```

`deletable` is declared `type = bool`, so it can never equal `""`. The condition was never true, so
every database in every environment has had `deletion_policy = "DELETE"` — including production
databases explicitly set to `deletable = false`. The variable has had no effect since it was added.

## Worth a reviewer's attention

**This is a behaviour change for every consumer** — anpr, account, console and enforcement all use
this module. For any instance with `deletable = false`, a plan that previously showed a database
being *destroyed* will now show it being *forgotten*. That is the documented intent and the safer
direction, but it will change plans people are used to reading.

Nothing changes for `deletable = true`.

## How it surfaced

While decommissioning a Temporal cluster in anpr, `production_temporal` was assumed protected by
`deletable = false`. It was not. What actually prevented a drop was Postgres refusing while sessions
were connected — which is not protection, because those sessions belong to the release being
destroyed and disappear in the same apply.

## Verified

`terraform validate` on the module, plus the repo's pre-commit suite: fmt, validate, tflint, trivy
and terraform-docs all pass.
